### PR TITLE
Test: LEAVE in outer loop leaves to the outer LOOP

### DIFF
--- a/src/core.fr
+++ b/src/core.fr
@@ -735,6 +735,9 @@ T{ 1 GD6 -> 1 }T
 T{ 2 GD6 -> 3 }T
 T{ 3 GD6 -> 4 1 2 }T
 
+T{ : GD7 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
+T{ GD7 -> }T
+
 \ ------------------------------------------------------------------------
 TESTING DEFINING WORDS: : ; CONSTANT VARIABLE CREATE DOES> >BODY
 

--- a/src/core.fr
+++ b/src/core.fr
@@ -735,9 +735,6 @@ T{ 1 GD6 -> 1 }T
 T{ 2 GD6 -> 3 }T
 T{ 3 GD6 -> 4 1 2 }T
 
-T{ : GD7 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
-T{ GD7 -> }T
-
 \ ------------------------------------------------------------------------
 TESTING DEFINING WORDS: : ; CONSTANT VARIABLE CREATE DOES> >BODY
 

--- a/src/coreplustest.fth
+++ b/src/coreplustest.fth
@@ -305,8 +305,9 @@ TESTING LEAVE in outer loop leaves to the outer LOOP
 \ Contributed by Johan Kotlinski
 
 T{ : GD10 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
-T{ : GD10 1 0 DO LEAVE 1 0 DO +LOOP 1 +LOOP ; -> }T
 T{ GD10 -> }T
+T{ : GD11 1 0 DO LEAVE 1 0 DO +LOOP 1 +LOOP ; -> }T
+T{ GD11 -> }T
 
 \ ------------------------------------------------------------------------------
 

--- a/src/coreplustest.fth
+++ b/src/coreplustest.fth
@@ -305,6 +305,7 @@ TESTING LEAVE in outer loop leaves to the outer LOOP
 \ Contributed by Johan Kotlinski
 
 T{ : GD10 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
+T{ : GD10 1 0 DO LEAVE 1 0 DO +LOOP 1 +LOOP ; -> }T
 T{ GD10 -> }T
 
 \ ------------------------------------------------------------------------------

--- a/src/coreplustest.fth
+++ b/src/coreplustest.fth
@@ -17,7 +17,7 @@
 \ tests are thought to be incomplete
 \
 \ Words tested in this file are:
-\     DO I +LOOP RECURSE ELSE >IN IMMEDIATE FIND IF...BEGIN...REPEAT ALLOT DOES>
+\     DO I +LOOP RECURSE ELSE >IN IMMEDIATE FIND IF...BEGIN...REPEAT ALLOT DOES> LEAVE
 \ and
 \     Parsing behaviour
 \     Number prefixes # $ % and 'A' character input
@@ -300,6 +300,13 @@ TESTING ALLOT ( n -- ) where n <= 0
 T{ HERE 5 ALLOT -5 ALLOT HERE = -> <TRUE> }T
 T{ HERE 0 ALLOT HERE = -> <TRUE> }T
  
+\ ------------------------------------------------------------------------------
+TESTING LEAVE in outer loop leaves to the outer LOOP
+\ Contributed by Johan Kotlinski
+
+T{ : GD8 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
+T{ GD8 -> }T
+
 \ ------------------------------------------------------------------------------
 
 CR .( End of additional Core tests) CR

--- a/src/coreplustest.fth
+++ b/src/coreplustest.fth
@@ -304,8 +304,8 @@ T{ HERE 0 ALLOT HERE = -> <TRUE> }T
 TESTING LEAVE in outer loop leaves to the outer LOOP
 \ Contributed by Johan Kotlinski
 
-T{ : GD8 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
-T{ GD8 -> }T
+T{ : GD10 1 0 DO LEAVE 1 0 DO LOOP 1 LOOP ; -> }T
+T{ GD10 -> }T
 
 \ ------------------------------------------------------------------------------
 


### PR DESCRIPTION
Added a test that verifies that LEAVE performed in outer DO-LOOP construct leaves to the outer LOOP.
This is aimed to catch the case where LEAVE erroneously leaves to the inner loop.