### PR TITLE
facility wordset test: remove case insensitivity

### DIFF
--- a/src/facilitytest.fth
+++ b/src/facilitytest.fth
@@ -43,7 +43,7 @@ T{ BEGIN-STRUCTURE STRCT2
       1 CELLS +FIELD F24
    END-STRUCTURE   -> }T
 
-T{ STRCT2 -> 3 chars 1 cells + }T   \ +FIELD doesn't align
+T{ STRCT2 -> 3 CHARS 1 CELLS + }T   \ +FIELD doesn't align
 T{ 0 F21 -> 0 }T
 T{ 0 F22 -> 1 }T
 T{ 0 F23 -> 3 }T


### PR DESCRIPTION
Compilation of the Facility test fails on case-sensitive Forth implementations. Fix this by using upper-case words to make it consistent with the rest of the file.