### PR TITLE
UPD coreexttest.fth - test `TO` for an immediate value

### DIFF
--- a/src/coreexttest.fth
+++ b/src/coreexttest.fth
@@ -424,6 +424,7 @@ T{ 444 TO VAL1 -> }T
 T{ VD1 -> 444 }T
 T{ 123 VALUE VAL3 IMMEDIATE VAL3 -> 123 }T
 T{ : VD3 VAL3 LITERAL ; VD3 -> 123 }T
+T{ : TO-VAL3 TO VAL3 ; 124 TO-VAL3 VAL3 VD3 -> 124 123 }T
 
 \ -----------------------------------------------------------------------------
 TESTING CASE OF ENDOF ENDCASE


### PR DESCRIPTION
Make sure `TO` correctly behaves when its argument is an immediate word created with `VALUE`.

See-also
  https://forth-standard.org/standard/core/TO#contribution-360