### PR TITLE
Fix text content of SSQ4

### DIFF
--- a/doc/testoutput.txt
+++ b/doc/testoutput.txt
@@ -90,7 +90,7 @@ The next test should display:
 One line...
 another line
 One line...
-anotherLine
+another line
 
 End of Core Extension word tests
 *********Screen 29 not modified

--- a/src/coreexttest.fth
+++ b/src/coreexttest.fth
@@ -755,7 +755,7 @@ T{ SSQ3 DROP 19 CHARS + C@ ->  92 }T    \ \\   \    Back Slash
 CR .( The next test should display:)
 CR .( One line...)
 CR .( another line)
-T{ : SSQ4 S\" \nOne line...\nanotherLine\n" TYPE ; SSQ4 -> }T
+T{ : SSQ4 S\" \nOne line...\nanother line\n" TYPE ; SSQ4 -> }T
 
 \ Test bare escapable characters appear as themselves
 T{ : SSQ5 S\" abeflmnqrtvxz" S" abeflmnqrtvxz" S= ; SSQ5 -> TRUE }T


### PR DESCRIPTION
Even on a standard-following platform, the
expected text wasn't the one about to be printed.